### PR TITLE
Fixed a timer issue where a vaadin-dialog-overlay was added unnecessarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>idle-notification</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <name>Idle Notification</name>
     <description>An addon that displays a notification and actions to the user before session-timeout</description>
 


### PR DESCRIPTION
Fixed an issue where the timer kept running which added the vaadin-dialog-overlay even when the idle-notification component was not in the DOM anymore.