### PR TITLE
Fix for _handleLoad not getting called at all and making the event listener removable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>idle-notification</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <name>Idle Notification</name>
     <description>An addon that displays a notification and actions to the user before session-timeout</description>
 

--- a/src/main/resources/META-INF/resources/frontend/idle-notification.js
+++ b/src/main/resources/META-INF/resources/frontend/idle-notification.js
@@ -221,6 +221,12 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
 
       /** @private */
       _dialogElement: Object,
+
+      /** @private */
+      _handleLoadListener: {
+         type: Object,
+         value: null,
+      }
     };
   }
 
@@ -344,8 +350,10 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener('load', this._handleLoad);
+    this.removeEventListener('load', this._handleLoadListener);
     this._clearTimeoutObject();
+    // to not trigger _handleLoad after disconnecting the component
+    this._displayProcessStarted = true;
   }
 
   /** @private */
@@ -355,7 +363,8 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
     let thisComponent = this;
     XMLHttpRequest.prototype.open = function () {
       currRequest = this;
-      this.addEventListener('load', () => thisComponent._handleLoad(currRequest));
+      thisComponent._handleLoadListener = (e) => thisComponent._handleLoad(currRequest);
+      this.addEventListener('load', thisComponent._handleLoadListener);
       origOpen.apply(this, arguments);
     };
   }

--- a/src/main/resources/META-INF/resources/frontend/idle-notification.js
+++ b/src/main/resources/META-INF/resources/frontend/idle-notification.js
@@ -355,7 +355,7 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
     let thisComponent = this;
     XMLHttpRequest.prototype.open = function () {
       currRequest = this;
-      this.addEventListener('load', thisComponent._handleLoad(currRequest));
+      this.addEventListener('load', () => thisComponent._handleLoad(currRequest));
       origOpen.apply(this, arguments);
     };
   }


### PR DESCRIPTION
In the earlier pull request the event listener was not getting called at all in the end. As a side effect it did fix my earlier issue however. Here's fix that to resolves that issue.