### PR TITLE
Don't reset timer on heartbeat requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,20 +1534,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@vaadin/vaadin-cookie-consent": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-cookie-consent/-/vaadin-cookie-consent-1.2.0.tgz",
-      "integrity": "sha512-F+KbxaauVmJsjbT5rhJ4lgPDtk9w8HmmFScE9FOHa0DnwlBNbpo26AE68+BcjeYmGHmXjQsndfvTqFQ10r3yZw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^2.4.1",
-        "@vaadin/vaadin-license-checker": "^2.1.0",
-        "@vaadin/vaadin-lumo-styles": "^1.1.0",
-        "@vaadin/vaadin-material-styles": "^1.1.0",
-        "@vaadin/vaadin-themable-mixin": "^1.6.1",
-        "cookieconsent": "^3.0.6"
-      }
-    },
     "@vaadin/vaadin-core-shrinkwrap": {
       "version": "14.4.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-core-shrinkwrap/-/vaadin-core-shrinkwrap-14.4.6.tgz",
@@ -2367,14 +2353,6 @@
         "@vaadin/vaadin-lumo-styles": "^1.1.0",
         "@vaadin/vaadin-material-styles": "^1.1.0",
         "@vaadin/vaadin-themable-mixin": "^1.6.1"
-      }
-    },
-    "@vaadin/vaadin-license-checker": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-license-checker/-/vaadin-license-checker-2.1.2.tgz",
-      "integrity": "sha512-oD6/MoavXyIZp6NWhkbJD5RKrpiWohhaQpgqjM0bFIthRr+1NoiG5R1w0uY3NIdMDuaXlsUFSQJ/Viz1v7F/jQ==",
-      "requires": {
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       }
     },
     "@vaadin/vaadin-list-box": {
@@ -3738,11 +3716,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
-    },
-    "cookieconsent": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
-      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag=="
     },
     "copy-concurrently": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@vaadin/vaadin-icons": "4.3.2",
     "@vaadin/vaadin-split-layout": "4.3.0",
     "@vaadin/vaadin-combo-box": "5.4.7",
-    "@vaadin/vaadin-cookie-consent": "1.2.0",
     "@vaadin/vaadin-core-shrinkwrap": "14.4.6",
     "@vaadin/vaadin-upload": "4.4.1",
     "@vaadin/vaadin-dialog": "2.5.2",
@@ -112,6 +111,6 @@
       "webpack-dev-server": "3.11.0",
       "chokidar": "^3.4.0"
     },
-    "hash": "1e06c9927c64930553395dd33da1b5912049cea3a29a8791b7eca1ab7ef03dee"
+    "hash": "a9dfd801b7530aaa0fba169b319aa420e5b223d0c1213f73e02d330df7ce23d2"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>idle-notification</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <name>Idle Notification</name>
     <description>An addon that displays a notification and actions to the user before session-timeout</description>
 

--- a/src/main/resources/META-INF/resources/frontend/idle-notification.js
+++ b/src/main/resources/META-INF/resources/frontend/idle-notification.js
@@ -372,9 +372,9 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
   /** @private */
   _handleLoad(currRequest) {
     if (
-        currRequest.responseURL.includes('?v-r') &&
         currRequest.status === 200 &&
-        !this._displayProcessStarted
+        !this._displayProcessStarted &&
+        this._isVaadinRequest(currRequest)
     ) {
       this._resetTimer();
       if (this.opened) {
@@ -462,6 +462,13 @@ class IdleNotification extends ThemableMixin(PolymerElement) {
       (e) => this._displayNotification(e),
       (this.maxInactiveInterval - this.secondsBeforeNotification) * 1000
     );
+  }
+
+  /** @private */
+  _isVaadinRequest(req) {
+    const reqUrl = new URL(req.responseURL);
+    // ignore heartbeat requests, so timeout value can be larger than heartbeat interval
+    return reqUrl.searchParams.has('v-r') && reqUrl.searchParams.get('v-r') !== 'heartbeat';
   }
 
   /** @private */


### PR DESCRIPTION
With the current implementation heartbeat requests reset the timer, making it impossible to specify idle time longer than the heartbeat interval in Vaadin, so 5 minutes by default.

This PR addresses this by ignoring heartbeat requests as needed.